### PR TITLE
Updated template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Puppet module to manage nsswitch that optionally allows for LDAP and VAS integra
 # Compatibility #
   * EL 5
   * EL 6
+  * Solaris 9
+  * Solaris 10
 
 ===
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -105,19 +105,19 @@ group:      files vas4
 
 sudoers:    files
 
-hosts:      files dns
+hosts:      files dns nis
 
 bootparams: files
 ethers:     files
 netmasks:   files
 networks:   files
-protocols:  files
+protocols:  files nis
 rpc:        files
-services:   files
+services:   files nis
 netgroup:   files nis
 publickey:  files
 automount:  files nis
-aliases:    files
+aliases:    files nis
 })
       }
     end
@@ -149,19 +149,19 @@ group:      files ldap vas4
 
 sudoers:    files ldap
 
-hosts:      files dns
+hosts:      files dns nis
 
 bootparams: files
 ethers:     files
 netmasks:   files
 networks:   files
-protocols:  files ldap
+protocols:  files ldap nis
 rpc:        files
-services:   files ldap
+services:   files ldap nis
 netgroup:   files ldap nis
 publickey:  files
 automount:  files ldap nis
-aliases:    files
+aliases:    files nis
 })
       }
     end

--- a/templates/nsswitch.conf.erb
+++ b/templates/nsswitch.conf.erb
@@ -7,16 +7,16 @@ group:      files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_v
 
 sudoers:    files<% if @ensure_ldap == 'present' %> ldap<% end %>
 
-hosts:      files dns
+hosts:      files dns<% if @ensure_vas == 'present' %> nis<% end %>
 
 bootparams: files
 ethers:     files
 netmasks:   files
 networks:   files
-protocols:  files<% if @ensure_ldap == 'present' %> ldap<% end %>
+protocols:  files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %> nis<% end %>
 rpc:        files
-services:   files<% if @ensure_ldap == 'present' %> ldap<% end %>
+services:   files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %> nis<% end %>
 netgroup:   files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %> nis<% end %>
 publickey:  files
 automount:  files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %> nis<% end %>
-aliases:    files
+aliases:    files<% if @ensure_vas == 'present' %> nis<% end %>


### PR DESCRIPTION
Added extra option to hosts, services, aliases:

I tested on SuSE, solaris 9 and Solaris 10, and the module worked out of the box.

I have updated the file templates/nsswitch.conf.erb  to include ldap/nis option for services, aliases and hosts. 
