### PR TITLE
Added workaround support for Solaris 11 registry

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,10 @@ class nsswitch (
   validate_re($vas_nss_module, '^vas(3|4)$',
     'Valid values for vas_nss_module are \'vas3\' and \'vas4\'.')
 
+  if $::kernel == 'SunOS' {
+    include nsswitch::solaris
+  }
+
   file { 'nsswitch_config_file':
     ensure  => file,
     path    => $config_file,

--- a/solaris.pp
+++ b/solaris.pp
@@ -1,0 +1,28 @@
+class nsswitch::solaris {
+
+  if $::kernelrelease == 5.11 {
+    exec { 'pre-nscfg':
+      path        => ['/usr/bin'],
+      command     => '/usr/bin/cp /etc/nsswitch.conf /tmp/smf-workaround',
+      subscribe   => File['/etc/nsswitch.conf'],
+      refreshonly => true
+    }
+
+    exec { 'nscfg':
+      path        => ['/usr/sbin'],
+      onlyif      => 'nscfg import -f svc:/system/name-service/switch:default',
+      command     => 'svcadm refresh name-service/switch',
+      subscribe   => Exec['pre-nscfg'],
+      refreshonly => true,
+      before      => Exec['post-nscfg']
+    }
+
+    exec { 'post-nscfg':
+      path        => ['/usr/bin'],
+      onlyif      => '/usr/bin/sleep 2',
+      command     => 'mv /tmp/smf-workaround /etc/nsswitch.conf',
+      subscribe   => Exec['nscfg'],
+      refreshonly => true
+    }
+  }
+}


### PR DESCRIPTION
Workaround for the fact that Solaris 11 updates nsswitch.conf when registry is updated, thereby forcing a puppet update every time the agent runs.
