### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 env:
-- PUPPET_VERSION=2.7.22
+- PUPPET_VERSION=2.7.23
 - PUPPET_VERSION=3.3.2
 notifications:
 email: false
@@ -9,7 +9,7 @@ rvm:
 - 1.8.7
 matrix:
   allow_failures:
-  - env: PUPPET_VERSION=2.7.22
+  - env: PUPPET_VERSION=2.7.23
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'

--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,11 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-  Dir['manifests/**/*.pp'].each do |path|
-    sh "puppet parser validate --noop #{path}"
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
   end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |spec_path|
-    sh "ruby -c #{spec_path}" unless spec_path =~ /spec\/fixtures/
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
-
 describe 'nsswitch' do
+
+  it { should compile.with_all_deps }
 
   describe 'included class' do
     context 'with defaults' do
       it {
-        should include_class('nsswitch')
+        should contain_class('nsswitch')
         should contain_file('nsswitch_config_file').with({
           'ensure'  => 'file',
           'path'    => '/etc/nsswitch.conf',
@@ -46,7 +47,7 @@ aliases:    files
       end
 
       it {
-        should include_class('nsswitch')
+        should contain_class('nsswitch')
         should contain_file('nsswitch_config_file').with({
           'ensure'  => 'file',
           'path'    => '/etc/nsswitch.conf',
@@ -87,7 +88,7 @@ aliases:    files
       end
 
       it {
-        should include_class('nsswitch')
+        should contain_class('nsswitch')
         should contain_file('nsswitch_config_file').with({
           'ensure'  => 'file',
           'path'    => '/etc/nsswitch.conf',
@@ -131,7 +132,7 @@ aliases:    files
       end
 
       it {
-        should include_class('nsswitch')
+        should contain_class('nsswitch')
         should contain_file('nsswitch_config_file').with({
           'ensure'  => 'file',
           'path'    => '/etc/nsswitch.conf',
@@ -230,7 +231,7 @@ aliases:    files
       end
 
       it {
-        should include_class('nsswitch')
+        should contain_class('nsswitch')
         should contain_file('nsswitch_config_file').with({
           'ensure'  => 'file',
           'path'    => '/etc/nsswitch.conf',
@@ -271,7 +272,7 @@ aliases:    files
       end
 
       it {
-        should include_class('nsswitch')
+        should contain_class('nsswitch')
         should contain_file('nsswitch_config_file').with({
           'ensure'  => 'file',
           'path'    => '/path/to/nsswitch.conf',
@@ -289,7 +290,7 @@ aliases:    files
 
       it do
         expect {
-          should include_class('nsswitch')
+          should contain_class('nsswitch')
         }.to raise_error(Puppet::Error)
       end
     end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
