### PR TITLE
Add Solaris 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Puppet v3 with Ruby 1.8.7, 1.9.3, and 2.0.0
   * EL 5
   * EL 6
   * Solaris 10
+  * Solaris 11
 
 ===
 

--- a/lib/puppet/provider/nsswitch/solaris.rb
+++ b/lib/puppet/provider/nsswitch/solaris.rb
@@ -1,0 +1,80 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+#
+
+Puppet::Type.type(:nsswitch).provide(:nsswitch) do
+    desc "Provider for name service switch configuration data"
+    confine :operatingsystem => [:solaris]
+    defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+    commands :svccfg => '/usr/sbin/svccfg', :svcprop => '/usr/bin/svcprop', :svcadm => '/usr/sbin/svcadm'
+
+    class << self; attr_accessor :nsswitch_fmri end
+    Nsswitch_fmri = "svc:/system/name-service/switch"
+
+    def self.instances
+        props = {}
+        svcprop("-p", "config", Nsswitch_fmri).each_line.collect do |line|
+            fullprop, type, value = line.split(" ", 2)
+            pg, prop = fullprop.split("/")
+            props[prop] = value \
+                if Puppet::Type.type(:nsswitch).validproperties.include? prop
+        end
+
+        props[:name] = "current"
+        return Array new(props)
+    end
+
+    Puppet::Type.type(:nsswitch).validproperties.each do |field|
+        define_method(field) do
+            begin
+                out = svcprop("-p", "config/" + field.to_s,
+                              Nsswitch_fmri).strip()
+                out = out.delete("\\")
+            rescue
+                # if the property isn't set, don't raise an error
+                nil
+            end
+        end
+
+        define_method(field.to_s + "=") do |should|
+            begin
+                svccfg("-s", Nsswitch_fmri, "setprop",
+                       "config/" + field.to_s, "=", '"' + should + '"')
+            rescue => detail
+                raise Puppet::Error,
+                    "Unable to set #{field.to_s} to #{should.inspect}\n"
+                    "#{detail}\n"
+            end
+        end
+    end
+
+    def flush
+      kernelversion = Facter.value('kernelversion')
+      if kernelversion == '11.0'
+        svcadm("refresh", Nsswitch_fmri)
+      else
+        svccfg("-s", Nsswitch_fmri, "refresh")
+      end
+    end
+end

--- a/lib/puppet/type/nsswitch.rb
+++ b/lib/puppet/type/nsswitch.rb
@@ -1,0 +1,122 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+#
+
+Puppet::Type.newtype(:nsswitch) do
+    @doc = "Name service switch configuration data"
+
+    newparam(:name) do
+        desc "The symbolic name for the nsswitch settings to use.  This name
+              is used for human reference only."
+        isnamevar
+    end
+
+    newproperty(:default) do
+        desc "The default configuration entry"
+    end
+
+    newproperty(:host) do
+        desc "The host database lookup override"
+    end
+
+    newproperty(:password) do
+        desc "The password database lookup override"
+    end
+
+    newproperty(:group) do
+        desc "The group database lookup override"
+    end
+
+    newproperty(:network) do
+        desc "The network database lookup override"
+    end
+
+    newproperty(:protocol) do
+        desc "The protocol database lookup override"
+    end
+
+    newproperty(:rpc) do
+        desc "The rpc database lookup override"
+    end
+
+    newproperty(:ether) do
+        desc "The ether database lookup override"
+    end
+
+    newproperty(:netmask) do
+        desc "The netmask database lookup override"
+    end
+
+    newproperty(:bootparam) do
+        desc "The bootparam database lookup override"
+    end
+
+    newproperty(:publickey) do
+        desc "The publickey database lookup override"
+    end
+
+    newproperty(:netgroup) do
+        desc "The netgroup database lookup override"
+    end
+
+    newproperty(:automount) do
+        desc "The automount database lookup override"
+    end
+
+    newproperty(:alias) do
+        desc "The alias database lookup override"
+    end
+
+    newproperty(:service) do
+        desc "The service database lookup override"
+    end
+
+    newproperty(:project) do
+        desc "The project database lookup override"
+    end
+
+    newproperty(:printer) do
+        desc "The printer database lookup override"
+    end
+
+    newproperty(:auth_attr) do
+        desc "The auth_attr database lookup override"
+    end
+
+    newproperty(:prof_attr) do
+        desc "The prof_attr database lookup override"
+    end
+
+    newproperty(:tnrhtp) do
+        desc "The tnrhtp database lookup override.  Requires trusted extensions"
+    end
+
+    newproperty(:tnrhdb) do
+        desc "The tnrhdb database lookup override.  Requires trusted extensions"
+    end
+
+    newproperty(:sudoer) do
+        desc "The sudoer database lookup override.  Used with sudo only"
+    end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,12 +98,30 @@ class nsswitch (
     validate_string($nsswitch_project_real)
   }
 
-  file { 'nsswitch_config_file':
-    ensure  => file,
-    path    => $config_file,
-    content => template('nsswitch/nsswitch.conf.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+  if $::operatingsystem == 'Solaris' and $::kernelrelease == '5.11' {
+    class {  'nsswitch::solaris11' :
+      ensure_ldap              => $ensure_ldap,
+      ensure_vas               => $ensure_vas,
+      vas_nss_module_passwd    => $vas_nss_module_passwd,
+      vas_nss_module_group     => $vas_nss_module_group,
+      vas_nss_module_automount => $vas_nss_module_automount,
+      vas_nss_module_netgroup  => $vas_nss_module_netgroup,
+      vas_nss_module_aliases   => $vas_nss_module_aliases,
+      vas_nss_module_services  => $vas_nss_module_services,
+      nsswitch_ipnodes_real    => $nsswitch_ipnodes_real,
+      nsswitch_printers_real   => $nsswitch_printers_real,
+      nsswitch_auth_attr_real  => $nsswitch_auth_attr_real,
+      nsswitch_prof_attr_real  => $nsswitch_prof_attr_real,
+      nsswitch_project_real    => $nsswitch_project_real,
+    }
+  } else {
+    file { 'nsswitch_config_file':
+      ensure  => file,
+      path    => $config_file,
+      content => template('nsswitch/nsswitch.conf.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
   }
 }

--- a/manifests/solaris11.pp
+++ b/manifests/solaris11.pp
@@ -1,0 +1,58 @@
+# This class is applied on Solaris kernelrelease 5.11
+# database sources and their lookup order  are  specified in SMF;
+# svc:/system/name-service/switch. /etc/nsswitch.conf is obsolete,
+# but regenerated from SMF for backward compatibility.
+class nsswitch::solaris11 (
+  $ensure_ldap,
+  $ensure_vas,
+  $vas_nss_module_passwd,
+  $vas_nss_module_group,
+  $vas_nss_module_automount,
+  $vas_nss_module_netgroup,
+  $vas_nss_module_aliases,
+  $vas_nss_module_services,
+  $nsswitch_ipnodes_real,
+  $nsswitch_printers_real,
+  $nsswitch_auth_attr_real,
+  $nsswitch_prof_attr_real,
+  $nsswitch_project_real,
+
+) {
+
+  $passwd_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %> <%= vas_nss_module_passwd %><% end %>")
+  $shadow_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %>")
+  $group_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %> <%= @vas_nss_module_group %><% end %>")
+  $sudoers_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %>")
+  $protocols_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %>")
+  $services_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %><% if @vas_nss_module_services != '' %> <%= @vas_nss_module_services %><% end %><% end %>")
+  $netgroup_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %><% if @vas_nss_module_netgroup != '' %> <%= @vas_nss_module_netgroup %><% end %><% end %>")
+  $automount_line = inline_template("files<% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %><% if @vas_nss_module_automount != '' %> <%= @vas_nss_module_automount %><% end %><% end %>")
+  $aliases_line = inline_template("files<% if @ensure_vas == 'present' %><% if @vas_nss_module_aliases != '' %> <%= @vas_nss_module_aliases %><% end %><% end %>")
+
+  nsswitch { 'Solaris11_switch':
+    password  => $passwd_line,
+    group     => $group_line,
+    sudoer    => $sudoers_line,
+    host      => 'files dns',
+    bootparam => 'files',
+    ether     => 'files',
+    netmask   => 'files',
+    network   => 'files',
+    protocol  => $protocols_line,
+    rpc       => 'files',
+    service   => $services_line,
+    netgroup  => $netgroup_line,
+    publickey => 'files',
+    automount => $automount_line,
+    alias     => $aliases_line,
+    printer   => $nsswitch_printers_real,
+    auth_attr => $nsswitch_auth_attr_real,
+    prof_attr => $nsswitch_prof_attr_real,
+    project   => $nsswitch_project_real,
+  }
+
+  service { 'switch' :
+    name      => 'name-service/switch',
+    ensure    => running,
+  }
+}


### PR DESCRIPTION
Add Solaris 11 support.
Solaris 11 uses SMF registry for a number of configurations and files are becoming obsolete, but retained for backward compatibilty. I have seen that this support would be available in future puppet version release (may be from 3.4.1), but there are already library codes that can implement this.

library provider/type source:
https://java.net/projects/solaris-userland/sources/gate/show/components/puppet/files/solaris/lib/puppet?rev=1878

I will get the code tested more and confirm here.
