### PR TITLE
Create enable_sss switch for nsswitch.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@
 class nsswitch (
   $config_file              = '/etc/nsswitch.conf',
   $ensure_ldap              = 'absent',
+  $ensure_sss               = 'absent',
   $ensure_vas               = 'absent',
   $vas_nss_module_passwd    = 'vas4',
   $vas_nss_module_group     = 'vas4',

--- a/templates/nsswitch.conf.erb
+++ b/templates/nsswitch.conf.erb
@@ -35,3 +35,4 @@ prof_attr:  <%= @nsswitch_prof_attr_real %>
 <% if @nsswitch_project_real != nil -%>
 project:    <%= @nsswitch_project_real %>
 <% end -%>
+

--- a/templates/nsswitch.conf.erb
+++ b/templates/nsswitch.conf.erb
@@ -5,7 +5,7 @@ passwd:     <%= @passwd_real %><% if @ensure_ldap == 'present' %> ldap<% end %><
 shadow:     <%= @shadow_real %><% if @ensure_ldap == 'present' %> ldap<% end %>
 group:      <%= @group_real %><% if @ensure_ldap == 'present' %> ldap<% end %><% if @ensure_vas == 'present' %> <%= @vas_nss_module_group %><% end %>
 
-sudoers:    files<% if @ensure_ldap == 'present' %> ldap<% end %>
+sudoers:    files<% if @ensure_ldap == 'present' -%> ldap<% end %><% if @ensure_sss == 'present' -%> sss<% end %>
 
 hosts:      <%= @hosts_real %>
 


### PR DESCRIPTION
Because we use FreeIPA, we need to have the ability for sudoers to use sss as an option.