### PR TITLE
Removal of sss as standard on rhel7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,17 +63,17 @@ class nsswitch (
     }
     'RedHat': {
       if $::operatingsystemmajrelease == '7' {
-        $default_passwd     = 'files'
+        $default_passwd     = 'files sss'
         $default_sudoers    = 'files'
-        $default_shadow     = 'files'
-        $default_group      = 'files'
+        $default_shadow     = 'files sss'
+        $default_group      = 'files sss'
         $default_hosts      = 'files dns myhostname'
-        $default_automount  = 'files'
-        $default_services   = 'files'
+        $default_automount  = 'files sss'
+        $default_services   = 'files sss'
         $default_bootparams = 'nisplus [NOTFOUND=return] files'
         $default_aliases    = 'files nisplus'
         $default_publickey  = 'nisplus'
-        $default_netgroup   = 'files'
+        $default_netgroup   = 'files sss'
       } else {
         $default_passwd     = 'files'
         $default_sudoers    = 'files'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,17 +63,17 @@ class nsswitch (
     }
     'RedHat': {
       if $::operatingsystemmajrelease == '7' {
-        $default_passwd     = 'files sss'
-        $default_sudoers    = 'files sss'
-        $default_shadow     = 'files sss'
-        $default_group      = 'files sss'
+        $default_passwd     = 'files'
+        $default_sudoers    = 'files'
+        $default_shadow     = 'files'
+        $default_group      = 'files'
         $default_hosts      = 'files dns myhostname'
-        $default_automount  = 'files sss'
-        $default_services   = 'files sss'
+        $default_automount  = 'files'
+        $default_services   = 'files'
         $default_bootparams = 'nisplus [NOTFOUND=return] files'
         $default_aliases    = 'files nisplus'
         $default_publickey  = 'nisplus'
-        $default_netgroup   = 'files sss'
+        $default_netgroup   = 'files'
       } else {
         $default_passwd     = 'files'
         $default_sudoers    = 'files'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -138,9 +138,9 @@ aliases:    files
 %{# This file is being maintained by Puppet.
 # DO NOT EDIT
 
-passwd:     files
-shadow:     files
-group:      files
+passwd:     files sss
+shadow:     files sss
+group:      files sss
 
 sudoers:    files
 
@@ -152,10 +152,10 @@ netmasks:   files
 networks:   files
 protocols:  files
 rpc:        files
-services:   files
-netgroup:   files
+services:   files sss
+netgroup:   files sss
 publickey:  nisplus
-automount:  files
+automount:  files sss
 aliases:    files nisplus
 })
       }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -138,11 +138,11 @@ aliases:    files
 %{# This file is being maintained by Puppet.
 # DO NOT EDIT
 
-passwd:     files sss
-shadow:     files sss
-group:      files sss
+passwd:     files
+shadow:     files
+group:      files
 
-sudoers:    files sss
+sudoers:    files
 
 hosts:      files dns myhostname
 
@@ -152,10 +152,10 @@ netmasks:   files
 networks:   files
 protocols:  files
 rpc:        files
-services:   files sss
-netgroup:   files sss
+services:   files
+netgroup:   files
 publickey:  nisplus
-automount:  files sss
+automount:  files
 aliases:    files nisplus
 })
       }


### PR DESCRIPTION
sss shoulden't be forced to be installed by the users to run a standard rhel 7.
Fix issue #42 RHEL7: sudoers and value sss
